### PR TITLE
Static inheritable properties must be enumerable

### DIFF
--- a/src/model/index.js
+++ b/src/model/index.js
@@ -2127,7 +2127,8 @@ Object.defineProperties(Model, {
         utils.fillIn(this._adapters, parentAdapters)
       }
       return this._adapters
-    }
+    },
+    enumerable: true
   },
 
   /**
@@ -2168,7 +2169,8 @@ Object.defineProperties(Model, {
         })
       }
       return this._collection
-    }
+    },
+    enumerable: true
   }
 })
 


### PR DESCRIPTION
Or else standard ES5 for-in syntax won’t work.
